### PR TITLE
fix: 解决子元素为 input、textarea 时，可见无法被采集的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.1.0-alpha.0](https://github.com/wuhonglei/Similo2-JS/compare/v1.0.15...v1.1.0-alpha.0) (2024-07-04)
+
+
+### Features
+
+* 允许用户自定义属性权重 ([ab9a41f](https://github.com/wuhonglei/Similo2-JS/commit/ab9a41f1a43439dda878b4399c5128a1673f5708))
+
 ### [1.0.15](https://github.com/wuhonglei/Similo2-JS/compare/v1.0.15-alpha.1...v1.0.15) (2024-05-15)
 
 ### [1.0.15-alpha.1](https://github.com/wuhonglei/Similo2-JS/compare/v1.0.15-alpha.0...v1.0.15-alpha.1) (2024-05-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.1.0-alpha.1](https://github.com/wuhonglei/Similo2-JS/compare/v1.1.0-alpha.0...v1.1.0-alpha.1) (2024-07-08)
+
+
+### Bug Fixes
+
+* 解决子元素为 input、textarea 时，text 无法被采集的问题 ([6e7c8dc](https://github.com/wuhonglei/Similo2-JS/commit/6e7c8dcaa3eb75f50a5865a223e8d7694f530eca))
+
 ## [1.1.0-alpha.0](https://github.com/wuhonglei/Similo2-JS/compare/v1.0.15...v1.1.0-alpha.0) (2024-07-04)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.1.0-alpha.2](https://github.com/wuhonglei/Similo2-JS/compare/v1.1.0-alpha.1...v1.1.0-alpha.2) (2024-07-08)
+
+
+### Bug Fixes
+
+* 解决 input placeholder 未被采集问题 ([c11a3ca](https://github.com/wuhonglei/Similo2-JS/commit/c11a3ca02f6c5c176e7d4fa8ac28bdf0e1e94475))
+
 ## [1.1.0-alpha.1](https://github.com/wuhonglei/Similo2-JS/compare/v1.1.0-alpha.0...v1.1.0-alpha.1) (2024-07-08)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opa/similo2",
-  "version": "1.1.0-alpha.0",
+  "version": "1.1.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@opa/similo2",
-      "version": "1.1.0-alpha.0",
+      "version": "1.1.0-alpha.1",
       "license": "ISC",
       "devDependencies": {
         "@commitlint/cli": "^17.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opa/similo2",
-  "version": "1.0.15",
+  "version": "1.1.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@opa/similo2",
-      "version": "1.0.15",
+      "version": "1.1.0-alpha.0",
       "license": "ISC",
       "devDependencies": {
         "@commitlint/cli": "^17.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opa/similo2",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@opa/similo2",
-      "version": "1.1.0-alpha.1",
+      "version": "1.1.0-alpha.2",
       "license": "ISC",
       "devDependencies": {
         "@commitlint/cli": "^17.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opa/similo2",
-  "version": "1.0.15",
+  "version": "1.1.0-alpha.0",
   "description": "Similarity-based Web Element Localization for Robust Test Automation",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opa/similo2",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "description": "Similarity-based Web Element Localization for Robust Test Automation",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opa/similo2",
-  "version": "1.1.0-alpha.0",
+  "version": "1.1.0-alpha.1",
   "description": "Similarity-based Web Element Localization for Robust Test Automation",
   "main": "lib/index.js",
   "types": "lib/types/index.d.ts",

--- a/src/interface/property.ts
+++ b/src/interface/property.ts
@@ -82,3 +82,6 @@ export interface ElementPropertiesOption {
   ignoreNames?: PropertyName[]; // 需要忽略的属性名
   excludeContainers: string[]; // 采集邻居文本时, 需要排除的容器 selector
 }
+
+// 允许用户自定义属性权重
+export type WeightByName = Partial<Record<PropertyName, number>>;

--- a/src/property.ts
+++ b/src/property.ts
@@ -12,14 +12,7 @@ import type {
   PropertyName,
 } from './interface/property';
 
-import {
-  elementIsVisible,
-  getElementByXPath,
-  getElementList,
-  getOwnElement,
-  isEmpty,
-  uniqElements,
-} from './utils/index';
+import { elementIsVisible, getElementByXPath } from './utils/index';
 import { getIdXPath, getXPath } from './utils/locator';
 import { getElementLocation, getNeighborText, getVisibleText } from './utils/neighbor';
 export { getElementByXPath, getElementByCssSelector, getElementBySelector } from './utils/index';

--- a/src/utils/neighbor.ts
+++ b/src/utils/neighbor.ts
@@ -37,7 +37,13 @@ function wordSegmentation(text: string): string[] {
 export function getVisibleText(element: Element): string[] {
   // textContent 会获取到隐藏元素的文本，所以使用 innerText
   const text = ['innerText', 'value', 'placeholder'].map((name) => ((element as any)[name] || '').trim()).find(Boolean);
-  return wordSegmentation(text);
+  const inputElements: NodeListOf<HTMLInputElement> = element.querySelectorAll('input, textarea');
+  // 解决 element 包含 input 元素时，input 元素的文本无法被获取的问题
+  const valueTexts = Array.from(inputElements)
+    .map((inputElement) => inputElement.value.trim())
+    .filter(Boolean);
+  const textList = [text, ...valueTexts].filter(Boolean);
+  return wordSegmentation(textList.join(' '));
 }
 
 function getElementHeight(element: Element): number {

--- a/src/utils/neighbor.ts
+++ b/src/utils/neighbor.ts
@@ -34,13 +34,18 @@ function wordSegmentation(text: string): string[] {
     .map((segment) => segment.segment);
 }
 
-export function getVisibleText(element: Element): string[] {
+export function getVisibleTextWithoutSegmentation(element: Element): string {
   // textContent 会获取到隐藏元素的文本，所以使用 innerText
   const text = ['innerText', 'value', 'placeholder'].map((name) => ((element as any)[name] || '').trim()).find(Boolean);
+  return text;
+}
+
+export function getVisibleText(element: Element): string[] {
+  const text = getVisibleTextWithoutSegmentation(element);
   const inputElements: NodeListOf<HTMLInputElement> = element.querySelectorAll('input, textarea');
   // 解决 element 包含 input 元素时，input 元素的文本无法被获取的问题
   const valueTexts = Array.from(inputElements)
-    .map((inputElement) => inputElement.value.trim())
+    .map((inputElement) => getVisibleTextWithoutSegmentation(inputElement))
     .filter(Boolean);
   const textList = [text, ...valueTexts].filter(Boolean);
   return wordSegmentation(textList.join(' '));

--- a/src/utils/neighbor.ts
+++ b/src/utils/neighbor.ts
@@ -42,9 +42,14 @@ export function getVisibleTextWithoutSegmentation(element: Element): string {
 
 export function getVisibleText(element: Element): string[] {
   const text = getVisibleTextWithoutSegmentation(element);
-  const inputElements: NodeListOf<HTMLInputElement> = element.querySelectorAll('input, textarea');
+  const inputElements: HTMLInputElement[] = [...element.querySelectorAll('input')].filter((input) =>
+    ['color', 'date', 'email', 'file', 'password', 'range', 'search', 'tel', 'text', 'time', 'url', 'week'].includes(
+      input.type,
+    ),
+  );
+  const textareaElements: HTMLTextAreaElement[] = [...element.querySelectorAll('textarea')];
   // 解决 element 包含 input 元素时，input 元素的文本无法被获取的问题
-  const valueTexts = Array.from(inputElements)
+  const valueTexts = [...inputElements, ...textareaElements]
     .map((inputElement) => getVisibleTextWithoutSegmentation(inputElement))
     .filter(Boolean);
   const textList = [text, ...valueTexts].filter(Boolean);


### PR DESCRIPTION
问题场景：邻居元素包含 input、textarea 时，通过 neighborElement.innerText 无法获取 input、textarea 中的 value 值

![image](https://github.com/wuhonglei/Similo2-JS/assets/12020551/86aa6b1e-ea97-444f-ba82-5cb8b393ca8f)

解决方法：获取邻居元素下的所有 input 和 textarea 元素的 value 值

@SamChan1204 
